### PR TITLE
Implement settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,30 @@
-# WP Tracy
+# Tracy on Wordpress - WP-Tracy
 
 [Tracy](https://github.com/nette/tracy) is an excellent PHP debugger bar from [Nette](https://nette.org) PHP framework. 
 WP Tracy is port to [WordPress](https://wordpress.org) for test environment.
 When it's activated, it automatically shows Tracy bar and displays within global WP constants and their values.
 
-## Installation
-
-1. Use command on your path: composer require ktstudio/wp-tracy
-2. Profit!
-3. You can optionally define PHP (boolean) constant WP_TRACY_CHECK_USER_LOGGED_IN to check only logged users...
-4. You can optionally define PHP constant WP_TRACY_ENABLE_MODE to set Tracy\Debugger::enable($mode)...
-5. You can optionally use wp_tracy_panels_filter to modify default panels array (full class names)
-
 ![WP Tracy](https://ktstudio.github.io/images/wp-tracy.png "Tracy bar auto-display after plugin activation")
 ![WP Tracy exception](https://ktstudio.github.io/images/wp-tracy-exception.png "Tracy exception dialog when is occured")
 
----
+## Installation
 
-Copyright © KTStudio.cz 2015
+Use command on your path:
+
+```
+composer require ktstudio/wp-tracy
+```
+
+## Configuration
+
+### Code
+
+1. You can optionally define PHP (boolean) constant WP_TRACY_CHECK_USER_LOGGED_IN to check only logged users...
+2. You can optionally define PHP constant WP_TRACY_ENABLE_MODE to set Tracy\Debugger::enable($mode)...
+3. You can optionally use wp_tracy_panels_filter to modify default panels array (full class names)
+
+### Settings page
+
+Composer bootstrap process for "WP Tracy" will activate the plugin and load the settings page automatically - the configuration will be acessible inside "Settings" menu.
+
+![shop dev wmc lv_wp-admin_options-general php_page tracy_debugger settings-updated true](https://user-images.githubusercontent.com/477326/33425087-5d8c6418-d5c6-11e7-9361-de0a50f58072.png "View of settings page")

--- a/src/index.php
+++ b/src/index.php
@@ -59,7 +59,10 @@ if (function_exists('add_action')) {
         Debugger::$maxLength = $options['tracyDebugger_text_maxLength'];
     }
     if (strlen($options['tracyDebugger_text_logDirectory']) > 0) {
-        Debugger::$logDirectory = __DIR__ . '/../../../../' . $options['tracyDebugger_text_logDirectory'];
+        $logDirectory = realpath(ABSPATH . $options['tracyDebugger_text_logDirectory']);
+        if (is_dir($logDirectory)) {
+            Debugger::$logDirectory = $logDirectory;
+        }
     }
     switch ($options['tracyDebugger_select_debuggerMode']) {
         case '1':
@@ -173,7 +176,7 @@ function tracyDebugger_settings_init()
     );
     add_settings_field(
         'tracyDebugger_checkbox_showLocation',
-        __('Show location', 'tracyDebugger'),
+        __('Show file location', 'tracyDebugger'),
         'tracyDebugger_checkbox_showLocation_render',
         'pluginPage',
         'tracyDebugger_pluginPage_section'
@@ -292,6 +295,26 @@ function tracyDebugger_text_logDirectory_render()
             'tracyDebugger'
         );
         ?></p>
+    <p class="description"><?php
+        echo __(
+            'Current location',
+            'tracyDebugger'
+        );
+        ?>: <?php
+            if (strlen($options['tracyDebugger_text_logDirectory']) > 0) {
+                $logDirectory = realpath(ABSPATH . $options['tracyDebugger_text_logDirectory']);
+                if (is_dir($logDirectory)) {
+                    echo '<code>' . $logDirectory . '</code>';
+                } else {
+                    echo '<code>' . ABSPATH . $options['tracyDebugger_text_logDirectory'] . '</code> (' . __(
+                        'does not exist!',
+                        'tracyDebugger'
+                    ) . ')';
+                }
+            } else {
+                echo '-';
+            }
+            ?></p>
     <?php
 }
 

--- a/src/index.php
+++ b/src/index.php
@@ -2,10 +2,10 @@
 use Tracy\Debugger;
 
 if (function_exists('add_action')) {
-    
+
     // Init tracy
     add_action("init", "wp_tracy_init_action", 1);
-    
+
     // Default options
     $options = get_option('tracyDebugger_settings');
     $changes = false;
@@ -60,7 +60,7 @@ if (function_exists('add_action')) {
     if ($changes) {
         update_option('tracyDebugger_settings', $options);
     }
-    
+
     // Configure
     Debugger::$strictMode = ($options['tracyDebugger_checkbox_strictMode'] == 1);
     Debugger::$showBar = ($options['tracyDebugger_checkbox_showBar'] == 1);
@@ -99,7 +99,7 @@ if (function_exists('add_action')) {
             define('WP_TRACY_ENABLE_MODE', Debugger::DETECT);
             break;
     }
-    
+
     // Settings page
     add_action('admin_menu', 'tracyDebugger_add_admin_menu');
     add_action('admin_init', 'tracyDebugger_settings_init');
@@ -244,7 +244,7 @@ function tracyDebugger_checkbox_disableForGuests_render()
 {
     $options = get_option('tracyDebugger_settings');
     ?>
-    <input type='hidden' name='tracyDebugger_settings[tracyDebugger_checkbox_disableForGuests]' value='0' />
+    <input type='hidden' name='tracyDebugger_settings[tracyDebugger_checkbox_disableForGuests]' value='0'/>
     <input type='checkbox'
            name='tracyDebugger_settings[tracyDebugger_checkbox_disableForGuests]' <?php checked($options['tracyDebugger_checkbox_disableForGuests'],
         1); ?> value='1'>
@@ -261,6 +261,7 @@ function tracyDebugger_checkbox_showBar_render()
 {
     $options = get_option('tracyDebugger_settings');
     ?>
+    <input type='hidden' name='tracyDebugger_settings[tracyDebugger_checkbox_showBar]' value='0'/>
     <input type='checkbox'
            name='tracyDebugger_settings[tracyDebugger_checkbox_showBar]' <?php checked($options['tracyDebugger_checkbox_showBar'],
         1); ?> value='1'>
@@ -277,6 +278,7 @@ function tracyDebugger_checkbox_strictMode_render()
 {
     $options = get_option('tracyDebugger_settings');
     ?>
+    <input type='hidden' name='tracyDebugger_settings[tracyDebugger_checkbox_strictMode]' value='0' />
     <input type='checkbox'
            name='tracyDebugger_settings[tracyDebugger_checkbox_strictMode]' <?php checked($options['tracyDebugger_checkbox_strictMode'],
         1); ?> value='1'>
@@ -293,6 +295,7 @@ function tracyDebugger_checkbox_showLocation_render()
 {
     $options = get_option('tracyDebugger_settings');
     ?>
+    <input type='hidden' name='tracyDebugger_settings[tracyDebugger_checkbox_showLocation]' value='0' />
     <input type='checkbox'
            name='tracyDebugger_settings[tracyDebugger_checkbox_showLocation]' <?php checked($options['tracyDebugger_checkbox_showLocation'],
         1); ?> value='1'>
@@ -368,20 +371,20 @@ function tracyDebugger_text_logDirectory_render()
             'tracyDebugger'
         );
         ?>: <?php
-            if (strlen($options['tracyDebugger_text_logDirectory']) > 0) {
-                $logDirectory = realpath(ABSPATH . $options['tracyDebugger_text_logDirectory']);
-                if (is_dir($logDirectory)) {
-                    echo '<code>' . $logDirectory . '</code>';
-                } else {
-                    echo '<code>' . ABSPATH . $options['tracyDebugger_text_logDirectory'] . '</code> (' . __(
+        if (strlen($options['tracyDebugger_text_logDirectory']) > 0) {
+            $logDirectory = realpath(ABSPATH . $options['tracyDebugger_text_logDirectory']);
+            if (is_dir($logDirectory)) {
+                echo '<code>' . $logDirectory . '</code>';
+            } else {
+                echo '<code>' . ABSPATH . $options['tracyDebugger_text_logDirectory'] . '</code> (' . __(
                         'does not exist!',
                         'tracyDebugger'
                     ) . ')';
-                }
-            } else {
-                echo '-';
             }
-            ?></p>
+        } else {
+            echo '-';
+        }
+        ?></p>
     <?php
 }
 
@@ -412,13 +415,20 @@ function tracyDebugger_select_enabledPanels_render()
     $options = get_option('tracyDebugger_settings');
     ?>
     <select name="tracyDebugger_settings[tracyDebugger_select_enabledPanels][]" size="7" multiple>
-        <option value="WpPanel" <?php selected(tracyDebugger_isPanelSelected('WpPanel', $options), true); ?>><?php echo __('WP', 'tracyDebugger') ?></option>
-        <option value="WpUserPanel" <?php selected(tracyDebugger_isPanelSelected('WpUserPanel', $options), true); ?>><?php echo __('User', 'tracyDebugger') ?></option>
-        <option value="WpPostPanel" <?php selected(tracyDebugger_isPanelSelected('WpPostPanel', $options), true); ?>><?php echo __('Post', 'tracyDebugger') ?></option>
-        <option value="WpQueryPanel" <?php selected(tracyDebugger_isPanelSelected('WpQueryPanel', $options), true); ?>><?php echo __('Query', 'tracyDebugger') ?></option>
-        <option value="WpQueriedObjectPanel" <?php selected(tracyDebugger_isPanelSelected('WpQueriedObjectPanel', $options), true); ?>><?php echo __('Queried object', 'tracyDebugger') ?></option>
-        <option value="WpDbPanel" <?php selected(tracyDebugger_isPanelSelected('WpDbPanel', $options), true); ?>><?php echo __('DB', 'tracyDebugger') ?></option>
-        <option value="WpRewritePanel" <?php selected(tracyDebugger_isPanelSelected('WpRewritePanel', $options), true); ?>><?php echo __('Rewrite', 'tracyDebugger') ?></option>
+        <option value="WpPanel" <?php selected(tracyDebugger_isPanelSelected('WpPanel', $options),
+            true); ?>><?php echo __('WP', 'tracyDebugger') ?></option>
+        <option value="WpUserPanel" <?php selected(tracyDebugger_isPanelSelected('WpUserPanel', $options),
+            true); ?>><?php echo __('User', 'tracyDebugger') ?></option>
+        <option value="WpPostPanel" <?php selected(tracyDebugger_isPanelSelected('WpPostPanel', $options),
+            true); ?>><?php echo __('Post', 'tracyDebugger') ?></option>
+        <option value="WpQueryPanel" <?php selected(tracyDebugger_isPanelSelected('WpQueryPanel', $options),
+            true); ?>><?php echo __('Query', 'tracyDebugger') ?></option>
+        <option value="WpQueriedObjectPanel" <?php selected(tracyDebugger_isPanelSelected('WpQueriedObjectPanel',
+            $options), true); ?>><?php echo __('Queried object', 'tracyDebugger') ?></option>
+        <option value="WpDbPanel" <?php selected(tracyDebugger_isPanelSelected('WpDbPanel', $options),
+            true); ?>><?php echo __('DB', 'tracyDebugger') ?></option>
+        <option value="WpRewritePanel" <?php selected(tracyDebugger_isPanelSelected('WpRewritePanel', $options),
+            true); ?>><?php echo __('Rewrite', 'tracyDebugger') ?></option>
     </select>
     <p class="description"><?php
         echo __(

--- a/src/index.php
+++ b/src/index.php
@@ -93,7 +93,9 @@ if (function_exists('add_action')) {
         Debugger::getLogger()->email = $options['tracyDebugger_text_email'];
     }
     if (strlen($options['tracyDebugger_text_emailSnooze']) > 0) {
-        Debugger::getLogger()->emailSnooze = $options['tracyDebugger_text_emailSnooze'];
+        if (strtotime($options['tracyDebugger_text_emailSnooze']) !== false) {
+            Debugger::getLogger()->emailSnooze = $options['tracyDebugger_text_emailSnooze'];
+        }
     }
     if (strlen($options['tracyDebugger_text_fromEmail']) > 0) {
         Debugger::getLogger()->fromEmail = $options['tracyDebugger_text_fromEmail'];
@@ -452,6 +454,27 @@ function tracyDebugger_text_emailSnooze_render()
             'tracyDebugger'
         );
         ?></p>
+    <p class="description"><?php
+        echo __(
+            'Current value',
+            'tracyDebugger'
+        );
+        ?>: <?php
+        if (strlen($options['tracyDebugger_text_emailSnooze']) > 0) {
+            $emailSnooze = strtotime($options['tracyDebugger_text_emailSnooze']);
+            if ($emailSnooze === false) {
+                echo '<span style="color: red">' . __(
+                    'Invalid',
+                    'tracyDebugger'
+                ) . '</span>';
+            } else {
+                echo '<span style="color: green">' . __(
+                        'Valid',
+                        'tracyDebugger'
+                    ) . '</span>';
+            }
+        }
+        ?></p>
     <?php
 }
 
@@ -459,7 +482,7 @@ function tracyDebugger_text_maxDepth_render()
 {
     $options = get_option('tracyDebugger_settings');
     ?>
-    <input type='text' name='tracyDebugger_settings[tracyDebugger_text_maxDepth]'
+    <input type='number' name='tracyDebugger_settings[tracyDebugger_text_maxDepth]'
            value='<?php echo $options['tracyDebugger_text_maxDepth']; ?>'>
     <p class="description"><?php
         echo __(
@@ -474,7 +497,7 @@ function tracyDebugger_text_maxLength_render()
 {
     $options = get_option('tracyDebugger_settings');
     ?>
-    <input type='text' name='tracyDebugger_settings[tracyDebugger_text_maxLength]'
+    <input type='number' name='tracyDebugger_settings[tracyDebugger_text_maxLength]'
            value='<?php echo $options['tracyDebugger_text_maxLength']; ?>'>
     <p class="description"><?php
         echo __(
@@ -538,10 +561,14 @@ function tracyDebugger_text_logDirectory_render()
             if (is_dir($logDirectory)) {
                 echo '<code>' . $logDirectory . '</code>';
             } else {
-                echo '<code>' . ABSPATH . $options['tracyDebugger_text_logDirectory'] . '</code> (' . __(
+                echo '<code>' .
+                    ABSPATH . $options['tracyDebugger_text_logDirectory'] .
+                    '</code> (<span style="color: red">' .
+                    __(
                         'does not exist!',
                         'tracyDebugger'
-                    ) . ')';
+                    ) .
+                    '</span>)';
             }
         } else {
             echo '-';
@@ -573,10 +600,14 @@ function tracyDebugger_text_errorTemplate_render()
             if (is_file($errorTemplate)) {
                 echo '<code>' . $errorTemplate . '</code>';
             } else {
-                echo '<code>' . ABSPATH . $options['tracyDebugger_text_errorTemplate'] . '</code> (' . __(
+                echo '<code>' .
+                    ABSPATH . $options['tracyDebugger_text_errorTemplate'] .
+                    '</code> (<span style="color: red">' .
+                    __(
                         'does not exist!',
                         'tracyDebugger'
-                    ) . ')';
+                    ) .
+                    '</span>)';
             }
         } else {
             echo '<code>' . '{tracyPackageRoot}/assets/Debugger/error.500.phtml' . '</code>';

--- a/src/index.php
+++ b/src/index.php
@@ -42,7 +42,15 @@ if (function_exists('add_action')) {
         $changes = true;
     }
     if (!isset($options['tracyDebugger_select_enabledPanels'])) {
-        $options['tracyDebugger_select_enabledPanels'] = '';
+        $options['tracyDebugger_select_enabledPanels'] = [
+            'WpPanel',
+            'WpUserPanel',
+            'WpPostPanel',
+            'WpQueryPanel',
+            'WpQueriedObjectPanel',
+            'WpDbPanel',
+            'WpRewritePanel',
+        ];
         $changes = true;
     }
     if ($changes) {
@@ -208,7 +216,7 @@ function tracyDebugger_settings_init()
     );
     add_settings_field(
         'tracyDebugger_select_enabledPanels',
-        __('Enabled panels', 'tracyDebugger'),
+        __('Additional Wordpress panels', 'tracyDebugger'),
         'tracyDebugger_select_enabledPanels_render',
         'pluginPage',
         'tracyDebugger_pluginPage_section'
@@ -378,6 +386,12 @@ function tracyDebugger_select_enabledPanels_render()
         <option value="WpDbPanel" <?php selected(tracyDebugger_isPanelSelected('WpDbPanel', $options), true); ?>><?php echo __('DB', 'tracyDebugger') ?></option>
         <option value="WpRewritePanel" <?php selected(tracyDebugger_isPanelSelected('WpRewritePanel', $options), true); ?>><?php echo __('Rewrite', 'tracyDebugger') ?></option>
     </select>
+    <p class="description"><?php
+        echo __(
+            'Use <kbd>Ctrl</kbd> or <kbd>Shift</kbd> to select multiple options or drag over with mouse.',
+            'tracyDebugger'
+        );
+        ?></p>
     <?php
 }
 

--- a/src/index.php
+++ b/src/index.php
@@ -41,6 +41,10 @@ if (function_exists('add_action')) {
         $options['tracyDebugger_select_debuggerMode'] = '1';
         $changes = true;
     }
+    if (!isset($options['tracyDebugger_select_enabledPanels'])) {
+        $options['tracyDebugger_select_enabledPanels'] = '';
+        $changes = true;
+    }
     if ($changes) {
         update_option('tracyDebugger_settings', $options);
     }
@@ -101,15 +105,29 @@ function wp_tracy_init_action()
     Debugger::enable(defined("WP_TRACY_ENABLE_MODE") ? WP_TRACY_ENABLE_MODE :
         null); // hooray, enabling debugging using Tracy
     // panels in the correct order
-    $defaultPanels = [
-        "WpTracy\\WpPanel",
-        "WpTracy\\WpUserPanel",
-        "WpTracy\\WpPostPanel",
-        "WpTracy\\WpQueryPanel",
-        "WpTracy\\WpQueriedObjectPanel",
-        "WpTracy\\WpDbPanel",
-        "WpTracy\\WpRewritePanel",
-    ];
+    $defaultPanels = [];
+    $options = get_option('tracyDebugger_settings');
+    if (tracyDebugger_isPanelSelected('WpPanel', $options)) {
+        $defaultPanels[] = "WpTracy\\WpPanel";
+    }
+    if (tracyDebugger_isPanelSelected('WpUserPanel', $options)) {
+        $defaultPanels[] = "WpTracy\\WpUserPanel";
+    }
+    if (tracyDebugger_isPanelSelected('WpPostPanel', $options)) {
+        $defaultPanels[] = "WpTracy\\WpPostPanel";
+    }
+    if (tracyDebugger_isPanelSelected('WpQueryPanel', $options)) {
+        $defaultPanels[] = "WpTracy\\WpQueryPanel";
+    }
+    if (tracyDebugger_isPanelSelected('WpQueriedObjectPanel', $options)) {
+        $defaultPanels[] = "WpTracy\\WpQueriedObjectPanel";
+    }
+    if (tracyDebugger_isPanelSelected('WpDbPanel', $options)) {
+        $defaultPanels[] = "WpTracy\\WpDbPanel";
+    }
+    if (tracyDebugger_isPanelSelected('WpRewritePanel', $options)) {
+        $defaultPanels[] = "WpTracy\\WpRewritePanel";
+    }
     $panels = apply_filters("wp_tracy_panels_filter", $defaultPanels);
     // panels registration
     foreach ($panels as $className) {
@@ -185,6 +203,13 @@ function tracyDebugger_settings_init()
         'tracyDebugger_text_logDirectory',
         __('Log directory', 'tracyDebugger'),
         'tracyDebugger_text_logDirectory_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+    add_settings_field(
+        'tracyDebugger_select_enabledPanels',
+        __('Enabled panels', 'tracyDebugger'),
+        'tracyDebugger_select_enabledPanels_render',
         'pluginPage',
         'tracyDebugger_pluginPage_section'
     );
@@ -335,6 +360,27 @@ function tracyDebugger_select_debuggerMode_render()
     <?php
 }
 
+function tracyDebugger_isPanelSelected($name, &$options)
+{
+    return in_array($name, $options['tracyDebugger_select_enabledPanels']);
+}
+
+function tracyDebugger_select_enabledPanels_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <select name="tracyDebugger_settings[tracyDebugger_select_enabledPanels][]" size="7" multiple>
+        <option value="WpPanel" <?php selected(tracyDebugger_isPanelSelected('WpPanel', $options), true); ?>><?php echo __('WP', 'tracyDebugger') ?></option>
+        <option value="WpUserPanel" <?php selected(tracyDebugger_isPanelSelected('WpUserPanel', $options), true); ?>><?php echo __('User', 'tracyDebugger') ?></option>
+        <option value="WpPostPanel" <?php selected(tracyDebugger_isPanelSelected('WpPostPanel', $options), true); ?>><?php echo __('Post', 'tracyDebugger') ?></option>
+        <option value="WpQueryPanel" <?php selected(tracyDebugger_isPanelSelected('WpQueryPanel', $options), true); ?>><?php echo __('Query', 'tracyDebugger') ?></option>
+        <option value="WpQueriedObjectPanel" <?php selected(tracyDebugger_isPanelSelected('WpQueriedObjectPanel', $options), true); ?>><?php echo __('Queried object', 'tracyDebugger') ?></option>
+        <option value="WpDbPanel" <?php selected(tracyDebugger_isPanelSelected('WpDbPanel', $options), true); ?>><?php echo __('DB', 'tracyDebugger') ?></option>
+        <option value="WpRewritePanel" <?php selected(tracyDebugger_isPanelSelected('WpRewritePanel', $options), true); ?>><?php echo __('Rewrite', 'tracyDebugger') ?></option>
+    </select>
+    <?php
+}
+
 function tracyDebugger_settings_section_callback()
 {
     echo __(
@@ -347,7 +393,7 @@ function tracyDebugger_options_page()
 {
     ?>
     <form action='options.php' method='post'>
-        <h2>Tracy debugger</h2>
+        <h2><?php echo __('Tracy debugger', 'tracyDebugger') ?></h2>
         <?php
         settings_fields('pluginPage');
         do_settings_sections('pluginPage');

--- a/src/index.php
+++ b/src/index.php
@@ -1,19 +1,104 @@
 <?php
+use Tracy\Debugger;
 
-add_action("init", "wp_tracy_init_action", 1);
+if (function_exists('add_action')) {
+    
+    // Init tracy
+    add_action("init", "wp_tracy_init_action", 1);
+    
+    // Default options
+    $options = get_option('tracyDebugger_settings');
+    $changes = false;
+    if (!isset($options['tracyDebugger_checkbox_strictMode'])) {
+        $options['tracyDebugger_checkbox_strictMode'] = 0;
+        $changes = true;
+    }
+    if (!isset($options['tracyDebugger_checkbox_showBar'])) {
+        $options['tracyDebugger_checkbox_showBar'] = 0;
+        $changes = true;
+    }
+    if (!isset($options['tracyDebugger_text_email'])) {
+        $options['tracyDebugger_text_email'] = '';
+        $changes = true;
+    }
+    if (!isset($options['tracyDebugger_text_maxDepth'])) {
+        $options['tracyDebugger_text_maxDepth'] = 3;
+        $changes = true;
+    }
+    if (!isset($options['tracyDebugger_text_maxLength'])) {
+        $options['tracyDebugger_text_maxLength'] = 150;
+        $changes = true;
+    }
+    if (!isset($options['tracyDebugger_checkbox_showLocation'])) {
+        $options['tracyDebugger_checkbox_showLocation'] = 0;
+        $changes = true;
+    }
+    if (!isset($options['tracyDebugger_text_logDirectory'])) {
+        $options['tracyDebugger_text_logDirectory'] = 'logs';
+        $changes = true;
+    }
+    if (!isset($options['tracyDebugger_select_debuggerMode'])) {
+        $options['tracyDebugger_select_debuggerMode'] = '1';
+        $changes = true;
+    }
+    if ($changes) {
+        update_option('tracyDebugger_settings', $options);
+    }
+    
+    // Configure
+    Debugger::$strictMode = ($options['tracyDebugger_checkbox_strictMode'] == 1);
+    Debugger::$showBar = ($options['tracyDebugger_checkbox_showBar'] == 1);
+    if (strlen($options['tracyDebugger_text_email']) > 0) {
+        Debugger::$email = $options['tracyDebugger_text_email'];
+    }
+    Debugger::$showLocation = ($options['tracyDebugger_checkbox_showLocation'] == 1);
+    if (strlen($options['tracyDebugger_text_maxDepth']) > 0) {
+        Debugger::$maxDepth = $options['tracyDebugger_text_maxDepth'];
+    }
+    if (strlen($options['tracyDebugger_text_maxLength']) > 0) {
+        Debugger::$maxLength = $options['tracyDebugger_text_maxLength'];
+    }
+    if (strlen($options['tracyDebugger_text_logDirectory']) > 0) {
+        Debugger::$logDirectory = __DIR__ . '/../../../../' . $options['tracyDebugger_text_logDirectory'];
+    }
+    switch ($options['tracyDebugger_select_debuggerMode']) {
+        case '1':
+            if (WP_DEBUG) {
+                define('WP_TRACY_ENABLE_MODE', Debugger::DEVELOPMENT);
+            } else {
+                define('WP_TRACY_ENABLE_MODE', Debugger::PRODUCTION);
+            }
+            break;
+        case '2':
+            define('WP_TRACY_ENABLE_MODE', Debugger::PRODUCTION);
+            break;
+        case '3':
+            define('WP_TRACY_ENABLE_MODE', Debugger::DEVELOPMENT);
+            break;
+        case '4':
+        default:
+            define('WP_TRACY_ENABLE_MODE', Debugger::DETECT);
+            break;
+    }
+    
+    // Settings page
+    add_action('admin_menu', 'tracyDebugger_add_admin_menu');
+    add_action('admin_init', 'tracyDebugger_settings_init');
+}
 
-function wp_tracy_init_action() {
+
+function wp_tracy_init_action()
+{
     if (defined("DOING_AJAX") && DOING_AJAX) {
         return; // for IE compatibility WordPress media upload
     }
-
     if (defined("WP_TRACY_CHECK_USER_LOGGED_IN") && WP_TRACY_CHECK_USER_LOGGED_IN && is_user_logged_in()) {
         return; // cancel for anonymous users
     }
-
-    Tracy\Debugger::enable(defined("WP_TRACY_ENABLE_MODE") ? WP_TRACY_ENABLE_MODE : null); // hooray, enabling debugging using Tracy
+    Debugger::enable(defined("WP_TRACY_ENABLE_MODE") ? WP_TRACY_ENABLE_MODE :
+        null); // hooray, enabling debugging using Tracy
     // panels in the correct order
-    $defaultPanels = array(
+    $defaultPanels = [
         "WpTracy\\WpPanel",
         "WpTracy\\WpUserPanel",
         "WpTracy\\WpPostPanel",
@@ -21,11 +106,230 @@ function wp_tracy_init_action() {
         "WpTracy\\WpQueriedObjectPanel",
         "WpTracy\\WpDbPanel",
         "WpTracy\\WpRewritePanel",
-    );
+    ];
     $panels = apply_filters("wp_tracy_panels_filter", $defaultPanels);
-
     // panels registration
     foreach ($panels as $className) {
-        Tracy\Debugger::getBar()->addPanel(new $className);
+        Debugger::getBar()->addPanel(new $className);
     }
+}
+
+function tracyDebugger_add_admin_menu()
+{
+    add_options_page('Tracy debugger', 'Tracy debugger', 'manage_options', 'tracy_debugger',
+        'tracyDebugger_options_page');
+}
+
+function tracyDebugger_settings_init()
+{
+    register_setting('pluginPage', 'tracyDebugger_settings');
+    add_settings_field(
+        'tracyDebugger_select_debuggerMode',
+        __('Debugger mode', 'tracyDebugger'),
+        'tracyDebugger_select_debuggerMode_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+    add_settings_section(
+        'tracyDebugger_pluginPage_section',
+        __('Configuration', 'tracyDebugger'),
+        'tracyDebugger_settings_section_callback',
+        'pluginPage'
+    );
+    add_settings_field(
+        'tracyDebugger_checkbox_showBar',
+        __('Show bar', 'tracyDebugger'),
+        'tracyDebugger_checkbox_showBar_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+    add_settings_field(
+        'tracyDebugger_checkbox_strictMode',
+        __('Strict mode', 'tracyDebugger'),
+        'tracyDebugger_checkbox_strictMode_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+    add_settings_field(
+        'tracyDebugger_text_email',
+        __('E-mail', 'tracyDebugger'),
+        'tracyDebugger_text_email_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+    add_settings_field(
+        'tracyDebugger_text_maxDepth',
+        __('Max depth', 'tracyDebugger'),
+        'tracyDebugger_text_maxDepth_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+    add_settings_field(
+        'tracyDebugger_text_maxLength',
+        __('Max length', 'tracyDebugger'),
+        'tracyDebugger_text_maxLength_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+    add_settings_field(
+        'tracyDebugger_checkbox_showLocation',
+        __('Show location', 'tracyDebugger'),
+        'tracyDebugger_checkbox_showLocation_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+    add_settings_field(
+        'tracyDebugger_text_logDirectory',
+        __('Log directory', 'tracyDebugger'),
+        'tracyDebugger_text_logDirectory_render',
+        'pluginPage',
+        'tracyDebugger_pluginPage_section'
+    );
+}
+
+function tracyDebugger_checkbox_showBar_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <input type='checkbox'
+           name='tracyDebugger_settings[tracyDebugger_checkbox_showBar]' <?php checked($options['tracyDebugger_checkbox_showBar'],
+        1); ?> value='1'>
+    <p class="description"><?php
+        echo __(
+            'The Debugger Bar is a floating panel. It is displayed in the bottom right corner of a page. You can move it using the mouse. It will remember its position after the page reloading.',
+            'tracyDebugger'
+        );
+        ?></p>
+    <?php
+}
+
+function tracyDebugger_checkbox_strictMode_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <input type='checkbox'
+           name='tracyDebugger_settings[tracyDebugger_checkbox_strictMode]' <?php checked($options['tracyDebugger_checkbox_strictMode'],
+        1); ?> value='1'>
+    <p class="description"><?php
+        echo __(
+            'Errors like a typo in a variable name or an attempt to open a nonexistent file generate reports of E_NOTICE or E_WARNING level. These can be easily overlooked and/or can be completely hidden in a web page graphic layout. Let Tracy manage them or enable strict mode and they will be displayed like errors.',
+            'tracyDebugger'
+        );
+        ?></p>
+    <?php
+}
+
+function tracyDebugger_checkbox_showLocation_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <input type='checkbox'
+           name='tracyDebugger_settings[tracyDebugger_checkbox_showLocation]' <?php checked($options['tracyDebugger_checkbox_showLocation'],
+        1); ?> value='1'>
+    <p class="description"><?php
+        echo __(
+            'The <code>dump()</code> function can display other useful information. Enabling this, adds a tooltip to every dumped object containing additional location information in file system.',
+            'tracyDebugger'
+        );
+        ?></p>
+    <?php
+}
+
+function tracyDebugger_text_email_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <input type='text' name='tracyDebugger_settings[tracyDebugger_text_email]'
+           value='<?php echo $options['tracyDebugger_text_email']; ?>'>
+    <p class="description"><?php
+        echo __(
+            'For a real professional the error log is a crucial source of information and he or she wants to be notified about any new error immediately. Tracy helps him. She is capable of sending an email for every new error record.',
+            'tracyDebugger'
+        );
+        ?></p>
+    <?php
+}
+
+function tracyDebugger_text_maxDepth_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <input type='text' name='tracyDebugger_settings[tracyDebugger_text_maxDepth]'
+           value='<?php echo $options['tracyDebugger_text_maxDepth']; ?>'>
+    <p class="description"><?php
+        echo __(
+            'For variable dumping, you can change the nesting depth. Naturally, lower values accelerate Tracy rendering.',
+            'tracyDebugger'
+        );
+        ?></p>
+    <?php
+}
+
+function tracyDebugger_text_maxLength_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <input type='text' name='tracyDebugger_settings[tracyDebugger_text_maxLength]'
+           value='<?php echo $options['tracyDebugger_text_maxLength']; ?>'>
+    <p class="description"><?php
+        echo __(
+            'For variable dumping, you can change the displayed strings length. Naturally, lower values accelerate Tracy rendering.',
+            'tracyDebugger'
+        );
+        ?></p>
+    <?php
+}
+
+function tracyDebugger_text_logDirectory_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <input type='text' name='tracyDebugger_settings[tracyDebugger_text_logDirectory]'
+           value='<?php echo $options['tracyDebugger_text_logDirectory']; ?>'>
+    <p class="description"><?php
+        echo __(
+            'Name of the directory where errors should be logged (relative to the project root).',
+            'tracyDebugger'
+        );
+        ?></p>
+    <?php
+}
+
+function tracyDebugger_select_debuggerMode_render()
+{
+    $options = get_option('tracyDebugger_settings');
+    ?>
+    <select name='tracyDebugger_settings[tracyDebugger_select_debuggerMode]'>
+        <option value='1' <?php selected($options['tracyDebugger_select_debuggerMode'],
+            1); ?>><?php echo __('Depends on WP_DEBUG', 'tracyDebugger') ?></option>
+        <option value='2' <?php selected($options['tracyDebugger_select_debuggerMode'],
+            2); ?>><?php echo __('Production', 'tracyDebugger') ?></option>
+        <option value='3' <?php selected($options['tracyDebugger_select_debuggerMode'],
+            3); ?>><?php echo __('Development', 'tracyDebugger') ?></option>
+        <option value='4' <?php selected($options['tracyDebugger_select_debuggerMode'],
+            3); ?>><?php echo __('Auto-detect - enabled only on localhost', 'tracyDebugger') ?></option>
+    </select>
+    <?php
+}
+
+function tracyDebugger_settings_section_callback()
+{
+    echo __(
+        '<p>Tracy library is a useful helper for everyday PHP programmers. It helps you&nbsp;to:</p><ol><li>quickly detect and correct errors</li><li>log errors</li><li>dump variables</li><li>measure execution time and memory consumption</li></ol><p>Read more about Tracy in their <a href="https://tracy.nette.org/" target="_blank">website</a>.</p>',
+        'tracyDebugger'
+    );
+}
+
+function tracyDebugger_options_page()
+{
+    ?>
+    <form action='options.php' method='post'>
+        <h2>Tracy debugger</h2>
+        <?php
+        settings_fields('pluginPage');
+        do_settings_sections('pluginPage');
+        submit_button();
+        ?>
+    </form>
+    <?php
 }


### PR DESCRIPTION
This commit implements settings page to configure on the fly, most of Tracy debugger config values via WP interface.

![shop dev wmc lv_wp-admin_options-general php_page tracy_debugger settings-updated true](https://user-images.githubusercontent.com/477326/33425087-5d8c6418-d5c6-11e7-9361-de0a50f58072.png)

This fixes #3 and #4.